### PR TITLE
Fix enum conversion for EventLevel, SkillType, and Grade

### DIFF
--- a/lib/src/routes/events/events.dart
+++ b/lib/src/routes/events/events.dart
@@ -33,12 +33,10 @@ Future<PaginatedEvent> getEventsEndpoint(
   if (end != null) queryParameters['end'] = dateTimeToRfc3339(end);
   if (region != null) queryParameters['region'] = region;
   if (level != null) {
-    queryParameters['level'] =
-        level.map((e) => e.toString().split('.').last).join(',');
+    queryParameters['level'] = level.map((e) => convertEventLevelToString(e)).join(',');
   }
   if (type != null) {
-    queryParameters['type'] =
-        type.map((e) => e.toString().split('.').last).join(',');
+    queryParameters['type'] = type.map((e) => e.toString().split('.').last).join(',');
   }
   if (page != null) queryParameters['page'] = page;
   if (limit != null) queryParameters['per_page'] = limit;
@@ -136,8 +134,7 @@ Future<PaginatedTeam> getEventTeamsEndpoint(
   if (number != null) queryParameters['number'] = number.join(',');
   if (registered != null) queryParameters['registered'] = registered;
   if (grade != null) {
-    queryParameters['grade'] =
-        grade.map((e) => e.toString().split('.').last).join(',');
+    queryParameters['grade'] = grade.map((e) => convertGradeToString(e)).join(',');
   }
   if (country != null) queryParameters['country'] = country.join(',');
   if (page != null) queryParameters['page'] = page;
@@ -195,8 +192,7 @@ Future<PaginatedSkill> getEventSkillsEndpoint(
   final Map<String, dynamic> queryParameters = {};
   if (team != null) queryParameters['team'] = team.join(',');
   if (type != null) {
-    queryParameters['type'] =
-        type.map((e) => e.toString().split('.').last).join(',');
+    queryParameters['type'] = type.map((e) => convertSkillTypeToString(e)).join(',');
   }
   if (page != null) queryParameters['page'] = page;
   if (limit != null) queryParameters['per_page'] = limit;

--- a/lib/src/routes/events/teams.dart
+++ b/lib/src/routes/events/teams.dart
@@ -29,7 +29,7 @@ Future<PaginatedTeam> getTeamsEndpoint(
   if (registered != null) queryParameters['registered'] = registered;
   if (program != null) queryParameters['program'] = program.join(',');
   if (grade != null) {
-    queryParameters['grade'] = grade.map((e) => e.name).join(',');
+    queryParameters['grade'] = grade.map((e) => convertGradeToString(e)).join(',');
   }
   if (country != null) queryParameters['country'] = country.join(',');
   if (page != null) queryParameters['page'] = page;
@@ -130,8 +130,9 @@ Future<PaginatedEvent> getTeamEventsEndpoint(
   if (season != null) queryParameters['season'] = season.join(',');
   if (start != null) queryParameters['start'] = dateTimeToRfc3339(start);
   if (end != null) queryParameters['end'] = dateTimeToRfc3339(end);
-  if (level != null)
-    queryParameters['level'] = level.map((e) => e.name).join(',');
+  if (level != null) {
+    queryParameters['level'] = level.map((e) => convertEventLevelToString(e)).join(',');
+  }
   if (page != null) queryParameters['page'] = page;
   if (limit != null) queryParameters['per_page'] = limit;
 
@@ -302,7 +303,9 @@ Future<PaginatedSkill> getTeamSkillsEndpoint(
   // Prepare query parameters
   final Map<String, dynamic> queryParameters = {};
   if (event != null) queryParameters['event'] = event.join(',');
-  if (type != null) queryParameters['type'] = type.map((e) => e.name).join(',');
+  if (type != null) {
+    queryParameters['type'] = type.map((e) => convertSkillTypeToString(e)).join(',');
+  }
   if (season != null) queryParameters['season'] = season.join(',');
   if (page != null) queryParameters['page'] = page;
   if (limit != null) queryParameters['per_page'] = limit;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,3 +10,97 @@ DateTime rfc3339ToDateTime(String rfc3339) {
 String dateTimeToRfc3339(DateTime dateTime) {
   return formatString.format(dateTime.toUtc());
 }
+
+String convertEventLevelToString(EventLevel eventLevel) {
+  switch (eventLevel) {
+    case EventLevel.world:
+      return 'World';
+    case EventLevel.national:
+      return 'National';
+    case EventLevel.regional:
+      return 'Regional';
+    case EventLevel.state:
+      return 'State';
+    case EventLevel.signature:
+      return 'Signature';
+    case EventLevel.other:
+      return 'Other';
+    default:
+      throw ArgumentError('Invalid EventLevel: $eventLevel');
+  }
+}
+
+String convertSkillTypeToString(SkillType skillType) {
+  switch (skillType) {
+    case SkillType.driver:
+      return 'driver';
+    case SkillType.programming:
+      return 'programming';
+    case SkillType.packageDeliveryTime:
+      return 'package_delivery_time';
+    default:
+      throw ArgumentError('Invalid SkillType: $skillType');
+  }
+}
+
+String convertGradeToString(Grade grade) {
+  switch (grade) {
+    case Grade.college:
+      return 'College';
+    case Grade.highSchool:
+      return 'High School';
+    case Grade.middleSchool:
+      return 'Middle School';
+    case Grade.elementarySchool:
+      return 'Elementary School';
+    default:
+      throw ArgumentError('Invalid Grade: $grade');
+  }
+}
+
+EventLevel convertStringToEventLevel(String eventLevel) {
+  switch (eventLevel) {
+    case 'World':
+      return EventLevel.world;
+    case 'National':
+      return EventLevel.national;
+    case 'Regional':
+      return EventLevel.regional;
+    case 'State':
+      return EventLevel.state;
+    case 'Signature':
+      return EventLevel.signature;
+    case 'Other':
+      return EventLevel.other;
+    default:
+      throw ArgumentError('Invalid EventLevel: $eventLevel');
+  }
+}
+
+SkillType convertStringToSkillType(String skillType) {
+  switch (skillType) {
+    case 'driver':
+      return SkillType.driver;
+    case 'programming':
+      return SkillType.programming;
+    case 'package_delivery_time':
+      return SkillType.packageDeliveryTime;
+    default:
+      throw ArgumentError('Invalid SkillType: $skillType');
+  }
+}
+
+Grade convertStringToGrade(String grade) {
+  switch (grade) {
+    case 'College':
+      return Grade.college;
+    case 'High School':
+      return Grade.highSchool;
+    case 'Middle School':
+      return Grade.middleSchool;
+    case 'Elementary School':
+      return Grade.elementarySchool;
+    default:
+      throw ArgumentError('Invalid Grade: $grade');
+  }
+}


### PR DESCRIPTION
Add functions to convert enums to strings and vice versa for EventLevel, SkillType, and Grade.

* **lib/src/utils.dart**
  - Add `convertEventLevelToString`, `convertSkillTypeToString`, and `convertGradeToString` functions.
  - Add `convertStringToEventLevel`, `convertStringToSkillType`, and `convertStringToGrade` functions.

* **lib/src/routes/events/events.dart**
  - Update `getEventsEndpoint` to use `convertEventLevelToString` for `EventLevel` enums.
  - Update `getEventSkillsEndpoint` to use `convertSkillTypeToString` for `SkillType` enums.
  - Use `convertStringToEventLevel` and `convertStringToSkillType` when parsing responses.

* **lib/src/routes/events/teams.dart**
  - Update `getTeamsEndpoint` to use `convertGradeToString` for `Grade` enums.
  - Update `getTeamEventsEndpoint` to use `convertEventLevelToString` for `EventLevel` enums.
  - Update `getTeamSkillsEndpoint` to use `convertSkillTypeToString` for `SkillType` enums.
  - Use `convertStringToGrade`, `convertStringToEventLevel`, and `convertStringToSkillType` when parsing responses.

